### PR TITLE
Python visualizer OpenGL improvements

### DIFF
--- a/python/cli/visualization/visualizer.py
+++ b/python/cli/visualization/visualizer.py
@@ -248,8 +248,6 @@ class Visualizer:
         self.outputQueue = []
         self.outputQueueMutex = Lock()
         self.clock = pygame.time.Clock()
-        self.projectionMatrix = None
-        self.viewMatrix = None
 
         # Window
         self.fullScreen = args.fullScreen
@@ -376,18 +374,20 @@ class Visualizer:
             top = 25.0 * self.cameraControls2D.zoom / self.aspectRatio
             projectionMatrix = getOrthographicProjectionMatrixOpenGL(left, right, bottom, top, -1000.0, 1000.0)
 
-        self.projectionMatrix = projectionMatrix
-        self.viewMatrix = viewMatrix
+        glMatrixMode(GL_PROJECTION)
+        glLoadMatrixf(projectionMatrix.transpose())
+        glMatrixMode(GL_MODELVIEW)
+        glLoadMatrixf(viewMatrix.transpose())
 
         self.map.render(cameraPose.getPosition(), viewMatrix, projectionMatrix)
-        if self.showGrid: self.grid.render(viewMatrix, projectionMatrix)
-        if self.showPoseTrail: self.poseTrail.render(viewMatrix, projectionMatrix)
+        if self.showGrid: self.grid.render()
+        if self.showPoseTrail: self.poseTrail.render()
         if self.args.customRenderCallback: self.args.customRenderCallback()
 
         if self.cameraMode in [CameraMode.THIRD_PERSON, CameraMode.TOP_VIEW]:
             modelMatrix = cameraPose.getCameraToWorldMatrix()
-            if self.showCameraModel: self.cameraModelRenderer.render(modelMatrix, viewMatrix, projectionMatrix)
-            if self.showCameraFrustum: self.cameraFrustumRenderer.render(modelMatrix, viewMatrix, projectionMatrix, self.cameraMode is CameraMode.TOP_VIEW)
+            if self.showCameraModel: self.cameraModelRenderer.render(modelMatrix)
+            if self.showCameraFrustum: self.cameraFrustumRenderer.render(modelMatrix, self.cameraMode is CameraMode.TOP_VIEW)
 
         if self.recorder: self.recorder.recordFrame()
         pygame.display.flip()
@@ -547,12 +547,6 @@ class Visualizer:
                 time.sleep(0.01)
 
         self.__close()
-
-    def getProjectionMatrix(self):
-        return self.projectionMatrix
-
-    def getViewMatrix(self):
-        return self.viewMatrix
 
     def printHelp(self):
         print("Control using the keyboard:")

--- a/python/cli/visualization/visualizer_renderers/renderers.py
+++ b/python/cli/visualization/visualizer_renderers/renderers.py
@@ -33,7 +33,12 @@ class CameraWireframeRenderer:
             [4, 1],
         ]
 
-    def render(self, modelMatrix, viewMatrix, projectionMatrix):
+    def render(self, modelMatrix):
+        # TODO: remove
+        # model->camera = model->world->camera = world->camera * model->world = viewMatrix * modelMatrix
+        glPushMatrix()
+        glMultMatrixf(modelMatrix.transpose())
+
         glLineWidth(self.lineWidth)
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
@@ -41,12 +46,6 @@ class CameraWireframeRenderer:
         glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
         glEnable(GL_DEPTH_TEST)
         glColor4fv(self.color)
-
-        modelView = viewMatrix @ modelMatrix
-        glMatrixMode(GL_MODELVIEW)
-        glLoadMatrixf(modelView.transpose())
-        glMatrixMode(GL_PROJECTION)
-        glLoadMatrixf(projectionMatrix.transpose())
 
         glBegin(GL_LINES)
         for edge in self.edges:
@@ -59,6 +58,7 @@ class CameraWireframeRenderer:
         glDisable(GL_BLEND)
         glDisable(GL_LINE_SMOOTH)
         glDisable(GL_DEPTH_TEST)
+        glPopMatrix()
 
 class KeyFrameRenderer:
     def __init__(self, color=np.array(DEFAULT_KEYFRAME_RGBA), scale=0.05, lineWidth=2):
@@ -75,11 +75,9 @@ class KeyFrameRenderer:
 
         for kfId in keyFrameCameraToWorldMatrices:
             modelMatrix = keyFrameCameraToWorldMatrices[kfId]
-            modelView = viewMatrix @ modelMatrix
-            glMatrixMode(GL_MODELVIEW)
-            glLoadMatrixf(modelView.transpose())
-            glMatrixMode(GL_PROJECTION)
-            glLoadMatrixf(projectionMatrix.transpose())
+
+            glPushMatrix()
+            glMultMatrixf(modelMatrix.transpose())
 
             glBegin(GL_LINES)
             for edge in self.cameraWireframe.edges:
@@ -88,6 +86,7 @@ class KeyFrameRenderer:
                 glVertex3f(p0[0], p0[1], p0[2])
                 glVertex3f(p1[0], p1[1], p1[2])
             glEnd()
+            glPopMatrix()
 
         glDisable(GL_BLEND)
         glDisable(GL_LINE_SMOOTH)
@@ -255,15 +254,8 @@ class PoseTrailRenderer:
         if self.maxLength is not None and len(self.poseTrail) > self.maxLength:
             self.poseTrail.pop(0)
 
-    def render(self, viewMatrix, projectionMatrix):
-        modelView = viewMatrix # pose trail is already in world coordinates -> model matrix is identity
-
+    def render(self):
         glLineWidth(self.lineWidth)
-        glMatrixMode(GL_MODELVIEW)
-        glLoadMatrixf(modelView.transpose())
-        glMatrixMode(GL_PROJECTION)
-        glLoadMatrixf(projectionMatrix.transpose())
-
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
         glEnable(GL_LINE_SMOOTH)
@@ -289,13 +281,7 @@ class GridRenderer:
         self.lineWidth = lineWidth
         self.bounds = [-radius * length, radius * length]
 
-    def render(self, viewMatrix, projectionMatrix):
-        modelView = viewMatrix # grid is defined in world coordinates
-        glMatrixMode(GL_MODELVIEW)
-        glLoadMatrixf(modelView.transpose())
-        glMatrixMode(GL_PROJECTION)
-        glLoadMatrixf(projectionMatrix.transpose())
-
+    def render(self):
         glLineWidth(self.lineWidth)
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
@@ -389,15 +375,11 @@ class CameraFrustumRenderer:
             ]
         ]
 
-    def render(self, modelMatrix, viewMatrix, projectionMatrix, render2d):
-        modelView = viewMatrix @ modelMatrix
+    def render(self, modelMatrix, render2d):
+        glPushMatrix()
+        glMultMatrixf(modelMatrix.transpose())
 
         glLineWidth(1)
-        glMatrixMode(GL_MODELVIEW)
-        glLoadMatrixf(modelView.transpose())
-        glMatrixMode(GL_PROJECTION)
-        glLoadMatrixf(projectionMatrix.transpose())
-
         glEnable(GL_DEPTH_TEST)
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
@@ -413,6 +395,7 @@ class CameraFrustumRenderer:
             glEnd()
 
         glDisable(GL_DEPTH_TEST)
+        glPopMatrix()
 
 def createPlaneMesh(scale, position, color):
     # 3 ---- 2

--- a/python/cli/visualization/visualizer_renderers/renderers.py
+++ b/python/cli/visualization/visualizer_renderers/renderers.py
@@ -34,8 +34,6 @@ class CameraWireframeRenderer:
         ]
 
     def render(self, modelMatrix):
-        # TODO: remove
-        # model->camera = model->world->camera = world->camera * model->world = viewMatrix * modelMatrix
         glPushMatrix()
         glMultMatrixf(modelMatrix.transpose())
 


### PR DESCRIPTION
Commands like `glTranslatef, glScalef, glMultMatrixf` now correctly work in the `customRenderCallback`. Also, user doesn't need to set projection & view matrix anymore.