### PR TITLE
Nerfstudio splatfacto support

### DIFF
--- a/python/cli/process/process.py
+++ b/python/cli/process/process.py
@@ -20,6 +20,7 @@ def define_args(parser):
     parser.add_argument('--device_preset', choices=['none', 'oak-d', 'k4a', 'realsense', 'android', 'android-tof', 'ios-tof', 'orbbec-astra2', 'orbbec-femto'], help="Automatically detected in most cases")
     parser.add_argument('--fast', action='store_true', help='Fast but lower quality settings')
     parser.add_argument('--mono', action='store_true', help='Monocular mode: disable ToF and stereo data')
+    parser.add_argument('--internal', action='append', type=str, help='Internal override parameters in the form --internal=name:value')
     parser.add_argument('--image_format', type=str, default='jpg', help="Color image format (use 'png' for top quality)")
     parser.add_argument("--preview", help="Show latest primary image as a preview", action="store_true")
     parser.add_argument("--preview3d", help="Show 3D visualization", action="store_true")
@@ -538,6 +539,11 @@ def process(args):
 
     if args.device_preset:
         device_preset = args.device_preset
+
+    if args.internal is not None:
+        for param in args.internal:
+            k, _, v = param.partition(':')
+            config[k] = v
 
     if device_preset: print(f"Selected device type: {device_preset}", flush=True)
     else: print("Warning! Couldn't automatically detect device preset, to ensure best results suply one via --device_preset argument", flush=True)


### PR DESCRIPTION
In Nerfstudio 1.0, the data format was changed a bit. The folders should now have a file called `sparse_pc.ply`. If it's not there, Nerfstudio asks to generate it automatically, but that does not seem to work as it generates it in a wrong coordinate system w.r.t., the other files. As a result, Gaussian Splatting still works but converges a lot slower (and presumably to somewhat worse results) becuase it does not have a valid point cloud as a starting point.

This PR fixes the issue (see commit https://github.com/SpectacularAI/sdk/pull/23/commits/ca77aadf87c0982e1b79e3c7a518ce1993f6aad7) and also piggy-backs https://github.com/SpectacularAI/sdk/commit/df08bfeb1bcf1210571683063441ae86a6ecbf48 & https://github.com/SpectacularAI/sdk/commit/dc6cbe05f1feaaf3b73e6eb46950b05509519c0a (minor cleanup)

Side note: the model was named from `gaussian-splatting` to `splatfacto`, which we need to update in our docs/guides.