### PR TITLE
Fix Nerfstudio up direction

### DIFF
--- a/python/cli/process/process.py
+++ b/python/cli/process/process.py
@@ -124,6 +124,7 @@ def convert_json_taichi_to_nerfstudio(d):
             "h": c['camera_height'],
             "aabb_scale": 16,
             "frames": [],
+            "orientation_override": "none", # stops Nerfstudio from breaking our "up" direction
             "ply_file_path": "./sparse_pc.ply"
         }
         cam_id = json.dumps(params, sort_keys=True)


### PR DESCRIPTION
This disables Nerfstudio's built-in mechanism that tries to guess the up direction from the images. Nerfstudio still auto-scales and auto-centers the results, which AFAIK, cannot currently be disabled without modifying Nerfstudio code.