### PR TITLE
Use default projection matrix in visualizer third person mode

### DIFF
--- a/python/cli/visualization/visualizer.py
+++ b/python/cli/visualization/visualizer.py
@@ -9,7 +9,7 @@ from OpenGL.GL import * # all prefixed with gl so OK to import *
 os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
 import pygame
 
-from .visualizer_renderers.util import lookAt, getOrthographicProjectionMatrixOpenGL
+from .visualizer_renderers.util import lookAt, getPerspectiveProjectionMatrixOpenGL, getOrthographicProjectionMatrixOpenGL
 from .visualizer_renderers.renderers import *
 
 class CameraMode(Enum):
@@ -363,7 +363,7 @@ class Visualizer:
             target = cameraToWorld[0:3, 3]
             if self.cameraSmooth: eye, target = self.cameraSmooth.update(eye, target, self.shouldPause)
             viewMatrix = self.cameraControls3D.transformViewMatrix(lookAt(eye, target, up))
-            projectionMatrix = cameraPose.camera.getProjectionMatrixOpenGL(near, far)
+            projectionMatrix = getPerspectiveProjectionMatrixOpenGL(60.0, self.aspectRatio, near, far)
         elif self.cameraMode == CameraMode.TOP_VIEW:
             eye = cameraToWorld[0:3, 3] + np.array([0, 0, 15])
             target = cameraToWorld[0:3, 3]

--- a/python/cli/visualization/visualizer_renderers/util.py
+++ b/python/cli/visualization/visualizer_renderers/util.py
@@ -44,3 +44,12 @@ def getOrthographicProjectionMatrixOpenGL(left, right, bottom, top, near, far):
         [0, 0, 2 / (far - near), -(far + near) / (far - near)],
         [0, 0, 0, 1]
     ], dtype=np.float32)
+
+def getPerspectiveProjectionMatrixOpenGL(fovy, aspect, near, far):
+    f = 1.0 / np.tan(np.radians(fovy) / 2.0)
+    return np.array([
+        [f / aspect, 0, 0, 0],
+        [0, -f, 0, 0],
+        [0, 0, (far + near) / (far - near), -2.0 * far * near / (far - near)],
+        [0, 0, 1, 0]
+    ], dtype=np.float32)


### PR DESCRIPTION
I think the "zooming"/distortion artifacts were happening because the third person projection matrix was using device's projection matrix. This was most apperent with fisheye lenses.