### PR TITLE
Add keydown callback option to Python visualizer

### DIFF
--- a/python/cli/visualization/visualizer.py
+++ b/python/cli/visualization/visualizer.py
@@ -215,6 +215,7 @@ class VisualizerArgs:
 
     # Callbacks
     customRenderCallback = None # Used to render custom OpenGL objects in user code
+    customKeyDownCallbacks = {} # User callback is called when event.type == pygame.KEYDOWN and event.key == key
 
 class Recorder:
     def __init__(self, recordPath, resolution):
@@ -439,6 +440,8 @@ class Visualizer:
                     else: pygame.display.set_mode((w, h), DOUBLEBUF | OPENGL)
                 elif event.key == pygame.K_h:
                     self.printHelp()
+                if event.key in self.args.customKeyDownCallbacks:
+                    self.args.customKeyDownCallbacks[event.key]()
             else:
                 if self.cameraMode is CameraMode.THIRD_PERSON: self.cameraControls3D.update(event)
                 if self.cameraMode is CameraMode.TOP_VIEW: self.cameraControls2D.update(event)

--- a/python/cli/visualization/visualizer.py
+++ b/python/cli/visualization/visualizer.py
@@ -399,7 +399,9 @@ class Visualizer:
             if event.type == pygame.QUIT:
                 self.shouldQuit = True
             elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_q: self.shouldQuit = True
+                if event.key in self.args.customKeyDownCallbacks:
+                    self.args.customKeyDownCallbacks[event.key]()
+                elif event.key == pygame.K_q: self.shouldQuit = True
                 elif event.key == pygame.K_SPACE: self.shouldPause = not self.shouldPause
                 elif event.key == pygame.K_c:
                     self.cameraMode = self.cameraMode.next()
@@ -440,8 +442,6 @@ class Visualizer:
                     else: pygame.display.set_mode((w, h), DOUBLEBUF | OPENGL)
                 elif event.key == pygame.K_h:
                     self.printHelp()
-                if event.key in self.args.customKeyDownCallbacks:
-                    self.args.customKeyDownCallbacks[event.key]()
             else:
                 if self.cameraMode is CameraMode.THIRD_PERSON: self.cameraControls3D.update(event)
                 if self.cameraMode is CameraMode.TOP_VIEW: self.cameraControls2D.update(event)


### PR DESCRIPTION
Enables user to bind keys to callbacks. User callbacks override the default `keydown` functionality in the visualizer.