### PR TITLE
Fix C++ recording tool clean up

### DIFF
--- a/cpp/k4a/record.cpp
+++ b/cpp/k4a/record.cpp
@@ -249,5 +249,8 @@ int main(int argc, char *argv[]) {
         inputThread.join();
     }
 
+    // Close VIO
+    session = nullptr;
+
     return EXIT_SUCCESS;
 }

--- a/cpp/orbbec/record.cpp
+++ b/cpp/orbbec/record.cpp
@@ -248,5 +248,8 @@ int main(int argc, char *argv[]) {
         inputThread.join();
     }
 
+    // Close VIO
+    session = nullptr;
+
     return EXIT_SUCCESS;
 }

--- a/cpp/realsense/record.cpp
+++ b/cpp/realsense/record.cpp
@@ -202,5 +202,8 @@ int main(int argc, char** argv) {
         inputThread.join();
     }
 
+    // Close VIO
+    session = nullptr;
+
     return 0;
 }


### PR DESCRIPTION
Calling VIO dtor ensures `mapperCallback` is no longer called after this line. So  we can safely clean up in [~Serializer](https://github.com/SpectacularAI/sdk/blob/93376c3b6d90209684852fbdf6030d75390a5b81/cpp/common/visualization/serialization.cpp#L118-L124).